### PR TITLE
Fix callback function return current element

### DIFF
--- a/Resources/public/js/ajax-uploader.js
+++ b/Resources/public/js/ajax-uploader.js
@@ -115,7 +115,7 @@ let $ = jQuery;
                     processData: false,
                     data: formData
                 }).done(function(response) {
-                    let  previewElement = $('.afb_preview_' + uploadId);
+                    let  previewElement = container.find('.afb_preview_' + uploadId);
 
                     previewElement.addClass('afb_upload_complete');
                     previewElement.removeClass('afb_upload_progressing');


### PR DESCRIPTION
Si on a deux input d'upload sur la même page $('.afb_preview_' + uploadId) c'est trop générique. On se retrouve avec un previewElement qui peut être un array de x éléments. 